### PR TITLE
Add Docker and Docker Compose support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ See the [Readme file](https://github.com/jsiegenthaler/hueget/blob/master/README
 # Bug Fixes and Improvements
 
 
+## 0.7.6 (2024-12-13)
+* Added Docker config (thanks @Yannis4444)
+
+
 ## 0.7.5 (2024-12-06)
 * Bumped dependencies: "node": "^22"
 * Bumped dependencies: "axios": "^1.7.9"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:22-slim
 
-ENV HUE_BRIDGE_IP="192.168.0.101"
-ENV HUE_USERNAME="yourPhilipsHueBridgeUsername"
+ENV HUE_BRIDGE_IP="yourPhilipsHueBridgeIpAddress"
+ENV HUE_USERNAME="yourPhilipsHueApiUsername"
 ENV PORT=3000
 
 WORKDIR /usr/src/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:22-slim
+
+ENV HUE_BRIDGE_IP="192.168.0.101"
+ENV HUE_USERNAME="yourPhilipsHueBridgeUsername"
+ENV PORT=3000
+
+WORKDIR /usr/src/app
+COPY . .
+
+# Install hueget
+RUN npm install hueget
+
+# Expose the API port
+EXPOSE $PORT
+
+# Start hueget
+CMD ["sh", "-c", "node hueget.js -i $HUE_BRIDGE_IP -u $HUE_USERNAME -p $PORT"]

--- a/README.md
+++ b/README.md
@@ -119,19 +119,6 @@ $ pm2 describe hueget
 ```
 For more information about pm2, see https://github.com/Unitech/pm2
 
-# Running hueget with Docker
-You can run `hueget` easily using Docker and Docker Compose. This approach simplifies the setup and ensures `hueget` is isolated and always running reliably.
-
-## Prerequisites
-- Install [Docker](https://www.docker.com/) and [Docker Compose](https://docs.docker.com/compose/).
-
-## Steps
-1. Use the provided `HUE_BRIDGE_IP` and `HUE_USERNAME` environment variables in the `docker-compose.yml` file to configure your Philips Hue Bridge connection.
-
-2. Build and run the Docker container:
-   ```bash
-   docker compose up -d
-   ```
 
 # Getting your Philips Hue Bridge API Username
 If you have [Homebridge](https://homebridge.io/), and the [homebridge-hue](https://github.com/ebaauw/homebridge-hue) plugin, look at the **users** section of the hue config. You will see the Hue bridge MAC address folowed by the Hue bridge api username
@@ -144,6 +131,21 @@ The username will look something like this:
 ```
 UBxWZChHseyjeFwAkwgbdQ08x9XASWpanZZVg-mj
 ```
+
+# Running hueget with Docker (optional, only if you use a Docker environment)
+You can run hueget easily using Docker and Docker Compose. This approach simplifies the setup in a Docker environment and ensures hueget is isolated and always running reliably.
+
+## Prerequisites
+- Install [Docker](https://www.docker.com/) and [Docker Compose](https://docs.docker.com/compose/).
+
+## Steps
+1. Use the provided `HUE_BRIDGE_IP` and `HUE_USERNAME` environment variables in the `docker-compose.yml` file to configure your Philips Hue Bridge connection.
+
+2. Build and run the Docker container:
+   ```bash
+   docker compose up -d
+   ```
+
 
 # Reading the Status of your Hue Lights or Groups with hueget
 Enter a URL (in the format shown below) into your browser and press Enter. The ip address is the ip address of the device running hueget, eg: a raspberry pi.

--- a/README.md
+++ b/README.md
@@ -119,6 +119,20 @@ $ pm2 describe hueget
 ```
 For more information about pm2, see https://github.com/Unitech/pm2
 
+# Running hueget with Docker
+You can run `hueget` easily using Docker and Docker Compose. This approach simplifies the setup and ensures `hueget` is isolated and always running reliably.
+
+## Prerequisites
+- Install [Docker](https://www.docker.com/) and [Docker Compose](https://docs.docker.com/compose/).
+
+## Steps
+1. Use the provided `HUE_BRIDGE_IP` and `HUE_USERNAME` environment variables in the `docker-compose.yml` file to configure your Philips Hue Bridge connection.
+
+2. Build and run the Docker container:
+   ```bash
+   docker compose up -d
+   ```
+
 # Getting your Philips Hue Bridge API Username
 If you have [Homebridge](https://homebridge.io/), and the [homebridge-hue](https://github.com/ebaauw/homebridge-hue) plugin, look at the **users** section of the hue config. You will see the Hue bridge MAC address folowed by the Hue bridge api username
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,6 @@ services:
     ports:
       - "3000:3000"
     environment:
-      HUE_BRIDGE_IP: "192.168.0.101" # Replace with your Hue Bridge IP
-      HUE_USERNAME: "yourPhilipsHueBridgeUsername" # Replace with your Hue username
+      HUE_BRIDGE_IP: "yourPhilipsHueBridgeIpAddress" # Replace with your Philips Hue bridge IP address
+      HUE_USERNAME: "yourPhilipsHueApiUsername" # Replace with your Philips Hue api username
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  hueget:
+    build:
+      context: .
+    container_name: hueget
+    ports:
+      - "3000:3000"
+    environment:
+      HUE_BRIDGE_IP: "192.168.0.101" # Replace with your Hue Bridge IP
+      HUE_USERNAME: "yourPhilipsHueBridgeUsername" # Replace with your Hue username
+    restart: unless-stopped


### PR DESCRIPTION
### Summary
This pull request adds Docker and Docker Compose support for `hueget`, making it easier to deploy and run the application in a containerized environment.

### Changes
- Added a `Dockerfile` for building a Docker image with `hueget`.
- Included a `docker-compose.yml` for easy configuration and deployment.
- Updated the README with a section on running `hueget` using Docker and Docker Compose.